### PR TITLE
Stop regenerating keys on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Client public key: <copy from wireguard client app>
 Allowed IPs [10.0.0.3]: 
 Wireguard listen port [51820]: 
 ```
-> Running the playbook multiple times will change the server private/public keys. 
 > Make sure to copy the new public key into the client config each time.
 
 ## Client configuration
@@ -49,7 +48,7 @@ Address = 10.0.0.3/24
 DNS = 1.1.1.1, 1.0.0.1
 
 [Peer]
-PublicKey = <server wg public key / changes every time we run the playbook>
+PublicKey = <server wg public key>
 AllowedIPs = 0.0.0.0/0
 Endpoint = <server public ip>:<wg port>
 ```

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -38,6 +38,7 @@
 
     - name: Create wg server and client keys
       ansible.builtin.shell: wg genkey | sudo tee /etc/wireguard/keys/server.key | wg pubkey | sudo tee /etc/wireguard/keys/server.key.pub
+      creates: /etc/wireguard/keys/server.key.pub
 
     - name: Get server key
       ansible.builtin.shell: cat /etc/wireguard/keys/server.key


### PR DESCRIPTION
You mention about keys being regenerated on every run - was this intentional?
If you run the playbook again to reconfigure the system, is it desirable to regenerate keys?

Feel free to use the space to just say that you wanted it to do it this way :D 

NOTE: I haven't tested this change as I don't have ansible, a system to test against/time right this second to spin up a docker container to run against, sorry :/

Also, this repo got posted on HN :) https://news.ycombinator.com/item?id=29913515